### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.16.6-buster as backend
+WORKDIR /go/src/powerbox-http-proxy
+COPY . .
+RUN go build
+
+FROM node:16.4.2-buster as frontend
+COPY . .
+RUN npm install
+RUN npm run build
+
+FROM zenhack/sandstorm-http-bridge:276
+COPY --from=backend /go/src/powerbox-http-proxy/powerbox-http-proxy /
+COPY --from=frontend /build /build/


### PR DESCRIPTION
This adds a `Dockerfile` that builds on the `sandstorm-http-bridge` base image and incorporates the build results of this repository (`/powerbox-http-proxy` and `/build/index.js`).

Right now, the version of each base image is unspecified, so each image defaults to `latest`.  I could set this explicitly if you would prefer the builds be fully reproducible.

On IRC, I had suggested that I might make a `Dockerfile` for this package and add it to https://github.com/zenhack/docker-spk/tree/master/base-images; however, doing so would have meant fetching a tarball of this repository, and it seemed easier just to `COPY . .` from here instead.